### PR TITLE
Remove Partytown due to CSP 'eval' restriction

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,19 +1,22 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
-import tailwind from "@astrojs/tailwind";
+import tailwind from '@astrojs/tailwind';
 import { autoNewTabExternalLinks } from './src/autoNewTabExternalLinks';
-
-import partytown from "@astrojs/partytown";
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://dominixz.com/',
-  integrations: [mdx(), sitemap(), tailwind(), partytown()],
-  markdown: {
-    extendDefaultPlugins: true,
-    rehypePlugins: [[autoNewTabExternalLinks, {
-      domain: 'localhost:4321'
-    }]]
-  }
+	site: 'https://dominixz.com/',
+	integrations: [mdx(), sitemap(), tailwind()],
+	markdown: {
+		extendDefaultPlugins: true,
+		rehypePlugins: [
+			[
+				autoNewTabExternalLinks,
+				{
+					domain: 'localhost:4321'
+				}
+			]
+		]
+	}
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@astrojs/check": "^0.9.2",
         "@astrojs/markdown-remark": "^5.2.0",
         "@astrojs/mdx": "^3.1.3",
-        "@astrojs/partytown": "^2.1.1",
         "@astrojs/rss": "^4.0.7",
         "@astrojs/sitemap": "^3.1.6",
         "@astrojs/tailwind": "^5.1.0",
@@ -168,15 +167,6 @@
       },
       "peerDependencies": {
         "astro": "^4.8.0"
-      }
-    },
-    "node_modules/@astrojs/partytown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.2.tgz",
-      "integrity": "sha512-1a9T5lqxtnrw0qLPo1KwliUvaaUzPNPtWucD8VxdwT7zqcpODFk1RzGgAgqVo+YhutFrTu/qclbtnOfXBuskjw==",
-      "dependencies": {
-        "@builder.io/partytown": "^0.10.2",
-        "mrmime": "^2.0.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -513,17 +503,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@builder.io/partytown": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@builder.io/partytown/-/partytown-0.10.2.tgz",
-      "integrity": "sha512-A9U+4PREWcS+CCYzKGIPovtGB/PBgnH/8oQyCE6Nr9drDJk6cMPpLQIEajpGPmG9tYF7N3FkRvhXm/AS9+0iKg==",
-      "bin": {
-        "partytown": "bin/partytown.cjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@emmetio/abbreviation": {

--- a/package.json
+++ b/package.json
@@ -1,32 +1,31 @@
 {
-  "name": "devolio",
-  "type": "module",
-  "version": "0.0.1",
-  "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro check && astro build",
-    "preview": "astro preview",
-    "astro": "astro"
-  },
-  "dependencies": {
-    "@astrojs/check": "^0.9.2",
-    "@astrojs/markdown-remark": "^5.2.0",
-    "@astrojs/mdx": "^3.1.3",
-    "@astrojs/partytown": "^2.1.1",
-    "@astrojs/rss": "^4.0.7",
-    "@astrojs/sitemap": "^3.1.6",
-    "@astrojs/tailwind": "^5.1.0",
-    "astro": "^4.14.2",
-    "sharp": "^0.33.5",
-    "tailwindcss": "^3.4.10",
-    "typescript": "^5.5.4",
-    "unist-util-visit": "^5.0.0"
-  },
-  "devDependencies": {
-    "@tailwindcss/typography": "^0.5.14",
-    "prettier": "^3.3.3",
-    "prettier-plugin-astro": "^0.14.1",
-    "vite": "^5.4.8"
-  }
+	"name": "devolio",
+	"type": "module",
+	"version": "0.0.1",
+	"scripts": {
+		"dev": "astro dev",
+		"start": "astro dev",
+		"build": "astro check && astro build",
+		"preview": "astro preview",
+		"astro": "astro"
+	},
+	"dependencies": {
+		"@astrojs/check": "^0.9.2",
+		"@astrojs/markdown-remark": "^5.2.0",
+		"@astrojs/mdx": "^3.1.3",
+		"@astrojs/rss": "^4.0.7",
+		"@astrojs/sitemap": "^3.1.6",
+		"@astrojs/tailwind": "^5.1.0",
+		"astro": "^4.14.2",
+		"sharp": "^0.33.5",
+		"tailwindcss": "^3.4.10",
+		"typescript": "^5.5.4",
+		"unist-util-visit": "^5.0.0"
+	},
+	"devDependencies": {
+		"@tailwindcss/typography": "^0.5.14",
+		"prettier": "^3.3.3",
+		"prettier-plugin-astro": "^0.14.1",
+		"vite": "^5.4.8"
+	}
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,8 +25,8 @@ const { title, description, image } = Astro.props;
     {
       GTAG_MEASUREMENT_ID &&
       <>
-        <script type='text/partytown' async src={'https://www.googletagmanager.com/gtag/js?id=' + GTAG_MEASUREMENT_ID}></script>
-        <script type='text/partytown' define:vars={{ GTAG_MEASUREMENT_ID }}>
+        <script async src={'https://www.googletagmanager.com/gtag/js?id=' + GTAG_MEASUREMENT_ID}></script>
+        <script define:vars={{ GTAG_MEASUREMENT_ID }} is:inline>
           window.dataLayer = window.dataLayer || [];
           function gtag() {
             dataLayer.push(arguments);


### PR DESCRIPTION
## Summary
- remove `@astrojs/partytown` integration
- embed Google Tag Manager directly without Partytown

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a028bdda4833298a7066cdfada32f